### PR TITLE
Add certificate blacklist to stripe.net [WIP]

### DIFF
--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -7,3 +7,4 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyProduct("Stripe.net")]
 [assembly: AssemblyCopyright("Copyright (C) Jayme Davis 2014")]
 [assembly: AssemblyVersion("2.0.0")]
+[assembly: InternalsVisibleTo("Stripe.Tests")]

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Stripe.net")]
 [assembly: AssemblyDescription("A .net client api for http://stripe.com")]
 [assembly: AssemblyCompany("Jayme Davis")]

--- a/src/Stripe.Tests/Stripe.Tests.csproj
+++ b/src/Stripe.Tests/Stripe.Tests.csproj
@@ -144,6 +144,7 @@
     <Compile Include="plans\when_creating_a_plan.cs" />
     <Compile Include="customers\when_creating_a_customer.cs" />
     <Compile Include="oauth\when_creating_an_invalid_oauth_token_request.cs" />
+    <Compile Include="requestor\certificate_blacklists.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Stripe\Stripe.csproj">

--- a/src/Stripe.Tests/requestor/certificate_blacklists.cs
+++ b/src/Stripe.Tests/requestor/certificate_blacklists.cs
@@ -1,0 +1,19 @@
+﻿using Machine.Specifications;
+using System;
+
+namespace Stripe.Tests
+{
+	public class certificate_blacklists
+	{
+		protected static Exception ex;
+
+		Because of = () =>
+			ex = Catch.Exception(() => Requestor.GetString("https://revoked.stripe.com:444/", ""));
+
+		It should_raise_an_authentication_exception = () =>
+			// ideally this would be more a specific exception type, but I developed
+			// this test on mono and ex.GetBaseException returned a mono-specific
+			// exception type
+			ex.ShouldBeOfType<System.Net.WebException>();
+	}
+}

--- a/src/Stripe.Tests/requestor/certificate_blacklists.cs
+++ b/src/Stripe.Tests/requestor/certificate_blacklists.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Stripe.Tests
 {
-	public class certificate_blacklists
+	public class when_requesting_a_blacklisted_certificate
 	{
 		protected static Exception ex;
 
@@ -16,4 +16,21 @@ namespace Stripe.Tests
 			// exception type
 			ex.ShouldBeOfType<System.Net.WebException>();
 	}
+
+	// This is to say a non-blacklisted but name-mismatched certificate.
+	// The goal here is to ensure that SSL policy checks are still working.
+	public class when_requesting_a_mismatched_certificate
+	{
+		protected static Exception ex;
+
+		Because of = () =>
+			ex = Catch.Exception(() => Requestor.GetString("https://mismatched.stripe.com/", ""));
+
+		It should_raise_an_authentication_exception = () =>
+			// ideally this would be more a specific exception type, but I developed
+			// this test on mono and ex.GetBaseException returned a mono-specific
+			// exception type
+			ex.ShouldBeOfType<System.Net.WebException>();
+	}
+
 }

--- a/src/Stripe/Infrastructure/Requestor.cs
+++ b/src/Stripe/Infrastructure/Requestor.cs
@@ -2,6 +2,9 @@
 using System.IO;
 using System.Net;
 using System.Text;
+using System.Net.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Stripe
 {
@@ -53,6 +56,35 @@ namespace Stripe
 			return request;
 		}
 
+		private static string[] blacklistedCertDigests = {
+			// api.stripe.com
+			"05C0B3643694470A888C6E7FEB5C9E24E823DC53",
+			// revoked.stripe.com
+			"5B7DC7FBC98D78BF76D4D4FA6F597A0C901FAD5C",
+		};
+
+
+		private static bool StripeCertificateVerificationCallback(
+			Object sender,
+			X509Certificate certificate,
+			X509Chain chain,
+			SslPolicyErrors sslPolicyErrors)
+		{
+			string cert_digest = certificate.GetCertHashString();
+			if(Array.Exists(blacklistedCertDigests, digest => digest.Equals(cert_digest, StringComparison.OrdinalIgnoreCase))) {
+				Console.WriteLine("Invalid server certificate: {0} ({1})", certificate.Subject, cert_digest);
+				Console.WriteLine("You tried to connect to a server that has a blacklisted SSL certificate, which means we cannot securely send data to that server. Please email support@stripe.com if you need help connecting to the correct API endpoint.");
+				return false;
+			}
+
+			// make sure there are no other SSL validation errors
+			if(sslPolicyErrors == SslPolicyErrors.None) {
+				return true;
+			}
+
+			return false;
+		}
+
 		private static string GetAuthorizationHeaderValue(string apiKey)
 		{
 			var token = Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Format("{0}:", apiKey)));
@@ -66,8 +98,10 @@ namespace Stripe
 
 		private static string ExecuteWebRequest(WebRequest webRequest)
 		{
+			RemoteCertificateValidationCallback verification_callback = new RemoteCertificateValidationCallback(StripeCertificateVerificationCallback);
 			try
 			{
+				ServicePointManager.ServerCertificateValidationCallback += verification_callback;
 				using (var response = webRequest.GetResponse())
 				{
 					return ReadStream(response.GetResponseStream());
@@ -90,6 +124,10 @@ namespace Stripe
 				}
 
 				throw;
+			}
+			finally
+			{
+			 ServicePointManager.ServerCertificateValidationCallback -= verification_callback;
 			}
 		}
 


### PR DESCRIPTION
This is mostly ready to go (modulo removing debugging code) but I don't think I'm using or setting ServicePointManager.ServerCertificateValidationCallback delegate correctly. When validation fails it's called on every request (as expected). When validation succeeds it isn't called again on successive requests.
